### PR TITLE
feat: Implement asdf oasdiff plugin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,3 +20,8 @@ jobs:
         uses: asdf-vm/actions/plugin-test@v2
         with:
           command: oasdiff --help
+      - name: asdf_plugin_test_1_10_23
+        uses: asdf-vm/actions/plugin-test@v2
+        with:
+          command: oasdiff --version
+          version: 1.10.23

--- a/bin/download
+++ b/bin/download
@@ -17,7 +17,7 @@ release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.tar.gz"
 download_release "$ASDF_INSTALL_VERSION" "$release_file"
 
 #  Extract contents of tar.gz file into the download directory
-tar -xzf "$release_file" -C "$ASDF_DOWNLOAD_PATH" --strip-components=1 || fail "Could not extract $release_file"
+tar -xzf "$release_file" -C "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $release_file"
 
 # Remove the tar.gz file since we don't need to keep it
 rm "$release_file"

--- a/bin/download
+++ b/bin/download
@@ -5,7 +5,7 @@ set -euo pipefail
 current_script_path=${BASH_SOURCE[0]}
 plugin_dir=$(dirname "$(dirname "$current_script_path")")
 
-# shellcheck source=../lib/utils.bash
+# shellcheck source=lib/utils.bash
 source "${plugin_dir}/lib/utils.bash"
 
 mkdir -p "$ASDF_DOWNLOAD_PATH"

--- a/bin/install
+++ b/bin/install
@@ -5,7 +5,7 @@ set -euo pipefail
 current_script_path=${BASH_SOURCE[0]}
 plugin_dir=$(dirname "$(dirname "$current_script_path")")
 
-# shellcheck source=../lib/utils.bash
+# shellcheck source=lib/utils.bash
 source "${plugin_dir}/lib/utils.bash"
 
 install_version "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/bin/latest-stable
+++ b/bin/latest-stable
@@ -5,7 +5,7 @@ set -euo pipefail
 current_script_path=${BASH_SOURCE[0]}
 plugin_dir=$(dirname "$(dirname "$current_script_path")")
 
-# shellcheck source=../lib/utils.bash
+# shellcheck source=lib/utils.bash
 . "${plugin_dir}/lib/utils.bash"
 
 curl_opts=(-sI)

--- a/bin/list-all
+++ b/bin/list-all
@@ -5,7 +5,7 @@ set -euo pipefail
 current_script_path=${BASH_SOURCE[0]}
 plugin_dir=$(dirname "$(dirname "$current_script_path")")
 
-# shellcheck source=../lib/utils.bash
+# shellcheck source=lib/utils.bash
 source "${plugin_dir}/lib/utils.bash"
 
 list_all_versions | sort_versions | xargs echo

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -39,7 +39,7 @@ download_release() {
 	local version filename url platform
 	version="$1"
 	filename="$2"
-	platform=$(get_platform)
+	platform=$(get_platform $version)
 
 	# TODO: Adapt the release URL convention for oasdiff
 	url="$GH_REPO/releases/download/v${version}/${TOOL_NAME}_${version}_$platform.tar.gz"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-GH_REPO="https://github.com/tufin/oasdiff"
+GH_REPO="https://github.com/Tufin/oasdiff"
 TOOL_NAME="oasdiff"
 TOOL_TEST="oasdiff --help"
 
@@ -36,15 +36,35 @@ list_all_versions() {
 }
 
 download_release() {
-	local version filename url
+	local version filename url platform
 	version="$1"
 	filename="$2"
+	platform=$(get_platform)
 
 	# TODO: Adapt the release URL convention for oasdiff
-	url="$GH_REPO/archive/v${version}.tar.gz"
+	url="$GH_REPO/releases/download/v${version}/${TOOL_NAME}_${version}_$platform.tar.gz"
 
 	echo "* Downloading $TOOL_NAME release $version..."
 	curl "${curl_opts[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"
+}
+
+get_platform() {
+  local version=$1
+
+  case $(uname) in
+    #Linux OS
+    Linux)
+      if [ "$(uname -m)" = "aarch64" ]; then
+        echo "linux-arm64"
+      else
+        echo "linux-amd64"
+      fi
+    ;;
+    #Mac OS
+    Darwin)
+      echo "darwin_all"
+    ;;
+  esac
 }
 
 install_version() {

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-]GH_REPO="https://github.com/tufin/oasdiff"
+GH_REPO="https://github.com/tufin/oasdiff"
 TOOL_NAME="oasdiff"
 TOOL_TEST="oasdiff --help"
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -55,9 +55,9 @@ get_platform() {
     #Linux OS
     Linux)
       if [ "$(uname -m)" = "aarch64" ]; then
-        echo "linux-arm64"
+        echo "linux_arm64"
       else
-        echo "linux-amd64"
+        echo "linux_amd64"
       fi
     ;;
     #Mac OS

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -39,7 +39,7 @@ download_release() {
 	local version filename url platform
 	version="$1"
 	filename="$2"
-	platform=$(get_platform $version)
+	platform=$(get_platform "$version")
 
 	# TODO: Adapt the release URL convention for oasdiff
 	url="$GH_REPO/releases/download/v${version}/${TOOL_NAME}_${version}_$platform.tar.gz"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -49,22 +49,22 @@ download_release() {
 }
 
 get_platform() {
-  local version=$1
+	local version=$1
 
-  case $(uname) in
-    #Linux OS
-    Linux)
-      if [ "$(uname -m)" = "aarch64" ]; then
-        echo "linux_arm64"
-      else
-        echo "linux_amd64"
-      fi
-    ;;
-    #Mac OS
-    Darwin)
-      echo "darwin_all"
-    ;;
-  esac
+	case $(uname) in
+	#Linux OS
+	Linux)
+		if [ "$(uname -m)" = "aarch64" ]; then
+			echo "linux_arm64"
+		else
+			echo "linux_amd64"
+		fi
+		;;
+	#Mac OS
+	Darwin)
+		echo "darwin_all"
+		;;
+	esac
 }
 
 install_version() {


### PR DESCRIPTION
Implement oasdiff plugin changes to be able to download binaries correctly.
Removed --strip-components from untar command to avoid root folder deletion, where is main binary.
Removed ']' incorrect character from GH_REPO env var.
Set correct download url path.
Added dynamic platform calculation to set it in download url correctly.
Add plugin test to check workflow pass correctly.